### PR TITLE
Design framework foundation: auto-fit grid, preview workflow, Starter project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,10 @@ VITE_REVERB_PORT="${REVERB_PORT}"
 VITE_REVERB_SCHEME="${REVERB_SCHEME}"
 VITE_APP_NAME="${APP_NAME}"
 
-# This is the project in the opensignage /resources/js/Projects folder
-VITE_PROJECT_PATH="EF29"
+# The active design project in /resources/js/Projects.
+# "Starter" is the generic example project shipped with Open Signage. Point this
+# at your own project folder to build and ship your own designs.
+VITE_PROJECT_PATH="Starter"
 
 # If set, all screen urls will need ?shared_secret=SHARED_SECRET to be accessed
 APP_SHARED_SECRET=""

--- a/README.md
+++ b/README.md
@@ -14,87 +14,67 @@
 ![GitHub All Releases](https://img.shields.io/github/downloads/thiritin/open-signage/total)
 # Open Signage
 
-Open Signage is a digital signage solution built on Laravel, Inertia.js, and Vue.js. This platform serves webpages for digital signage screens, running on Chrome in kiosk mode. Utilizing Socketi, Open Signage dynamically updates data on screens. Users can create playlists for their screens, allowing for rotating announcements and various media presentations.
+Open Signage is a **framework for building digital‑signage designs**, built on
+Laravel, Inertia.js and Vue.js. You write your screens as Vue components, preview
+them instantly in the browser with mock data, and the platform handles
+playlists, scheduling, live updates (via Laravel Reverb) and kiosk delivery to
+Chrome.
 
-**ATTENTION!!** This is primarily used for Eurofurence (Hamburg, CCH). It is primarily suited at developers having knowledge of Vue.js and possibly a bit Laravel.
-Feel free to drop me a message at me@thiritin.com for commercial support.
+It ships with:
+
+- A generic **Starter** project you can copy to bootstrap your own designs.
+- An **auto‑fit + scale‑to‑fit grid system** so designs fit any screen
+  resolution — never larger than the screen — without hand‑tuning.
+- A **`/preview` workflow** to render any design standalone with mock data — no
+  database, playlist or websocket server required.
+- **Seeders** that produce a working demo screen on a fresh clone.
+
+> Building a real deployment? Keep your event-/customer‑specific designs in their
+> own repo and drop the project folder into `resources/js/Projects/`. The
+> framework stays generic. For commercial support, contact me@thiritin.com.
 
 ## Features
 
-- Dynamic data update with Socketi
-- Playlist creation for rotating announcements
-- Operates with Chrome in kiosk mode
+- Auto‑fit / scale‑to‑fit grid + block layout system
+- Standalone design preview with mock data (`/preview`)
+- Live data updates over websockets (Laravel Reverb)
+- Playlists, scheduling and rooms managed from a Filament admin
+- Runs full‑screen in Chrome kiosk mode
 
 ## Prerequisites
 
-- PHP 8.1 or higher
-- Node.js & npm/yarn
+- PHP 8.2 or higher
+- Node.js & npm
 - Composer
-- Laravel
 
-## Installation
+## Quick start
 
-1. Clone the repository:
-
-```
+```bash
 git clone https://github.com/thiritin/open-signage.git
-```
-
-2. Navigate into the project directory:
-
-```
 cd open-signage
-```
 
-3. Install PHP dependencies:
-
-```
 composer install
-```
-
-4. Install JavaScript dependencies:
-
-```
 npm install
-```
 
-5. Copy the `.env.example` file to create your own `.env` file:
-
-```
 cp .env.example .env
-```
-
-6. Set your application key:
-
-```
 php artisan key:generate
+
+# Schema + a working demo (a "demo" screen, Starter playlist, rooms, schedule):
+php artisan migrate --seed
+
+php artisan serve     # http://localhost:8000  (or ./vendor/bin/sail up)
+npm run dev           # Vite dev server with hot reload
 ```
 
-7. Set up your database credentials in the `.env` file.
+Then open:
 
-8. Run database migrations:
+- `http://localhost:8000/preview` — preview designs with mock data
+- `http://localhost:8000/screens/demo` — the seeded demo screen
+- `http://localhost:8000/admin` — admin (`me@thiritin.com` / `password`)
 
-```
-php artisan migrate
-```
-
-## Usage
-
-1. Start the Laravel server:
-
-```
-./vendor/bin/sail up
-```
-
-Or use 
-
-2. Start vite dev mode:
-
-```
-vite
-```
-
-Open Signage should now be accessible at `http://localhost`.
+**👉 Full developer guide: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)** —
+how the grid system works, the preview workflow, and how to create your own
+project.
 
 ## Contributing
 

--- a/app/Http/Controllers/PreviewController.php
+++ b/app/Http/Controllers/PreviewController.php
@@ -23,7 +23,8 @@ class PreviewController extends Controller
             abort(404);
         }
 
-        $project = config('app.default_project') ?: (env('VITE_PROJECT_PATH') ?: 'Starter');
+        // config('app.default_project') is bound to the VITE_PROJECT_PATH env.
+        $project = config('app.default_project') ?: 'Starter';
 
         $pages = $this->componentNames("resources/js/Projects/{$project}/Pages/*.vue");
         $layouts = $this->componentNames("resources/js/Projects/{$project}/Layouts/*.vue");

--- a/app/Http/Controllers/PreviewController.php
+++ b/app/Http/Controllers/PreviewController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+/**
+ * Dev-only "design preview" controller.
+ *
+ * Lets a developer preview ANY signage design Vue component standalone in the
+ * browser with realistic mock data. No database, screens, playlists or
+ * websocket (Reverb/Echo) server required.
+ *
+ * This is gated to debug / local environments only.
+ */
+class PreviewController extends Controller
+{
+    public function __invoke(Request $request, $component = null)
+    {
+        // Dev-only tool: never expose in production.
+        if (! config('app.debug') && ! app()->environment('local')) {
+            abort(404);
+        }
+
+        $project = config('app.default_project') ?: (env('VITE_PROJECT_PATH') ?: 'Starter');
+
+        $pages = $this->componentNames("resources/js/Projects/{$project}/Pages/*.vue");
+        $layouts = $this->componentNames("resources/js/Projects/{$project}/Layouts/*.vue");
+        $projects = $this->projectNames();
+
+        $selectedPage = $component ?: ($pages[0] ?? null);
+
+        $selectedLayout = $request->query('layout');
+        if (! $selectedLayout) {
+            $selectedLayout = in_array('None', $layouts, true) ? 'None' : ($layouts[0] ?? 'None');
+        }
+
+        return Inertia::render('Preview', [
+            'project' => $project,
+            'pages' => $pages,
+            'layouts' => $layouts,
+            'projects' => $projects,
+            'selectedPage' => $selectedPage,
+            'selectedLayout' => $selectedLayout,
+        ]);
+    }
+
+    /**
+     * Return the base names (without `.vue`) of files matching a glob,
+     * relative to the application base path.
+     */
+    protected function componentNames(string $relativeGlob): array
+    {
+        $files = glob(base_path($relativeGlob)) ?: [];
+
+        return collect($files)
+            ->map(fn ($file) => pathinfo($file, PATHINFO_FILENAME))
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Return the names of every project directory under resources/js/Projects.
+     */
+    protected function projectNames(): array
+    {
+        $dirs = glob(base_path('resources/js/Projects/*'), GLOB_ONLYDIR) ?: [];
+
+        return collect($dirs)
+            ->map(fn ($dir) => basename($dir))
+            ->sort()
+            ->values()
+            ->all();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,10 +18,16 @@ class DatabaseSeeder extends Seeder
         $this->call(EmergencySeeder::class);
         $this->call(SystemSeeder::class);
 
-        // Wild Times Seeder
-        $this->call(WildTimesSeeder::class);
-        $this->call(EurofurenceSeeder::class);
-        $this->call(FurcietySeeder::class);
+        // Generic "Starter" demo (screen at /screens/demo).
+        $this->call(StarterSeeder::class);
+
+        // Legacy / event-specific seeders. These are no longer auto-run now
+        // that the app is a generic framework, but the seeder files are kept
+        // and can still be run manually, e.g.:
+        //   php artisan db:seed --class=WildTimesSeeder
+        // $this->call(WildTimesSeeder::class);
+        // $this->call(EurofurenceSeeder::class);
+        // $this->call(FurcietySeeder::class);
 
         if (App::isLocal()) {
             User::firstOrCreate([

--- a/database/seeders/StarterSeeder.php
+++ b/database/seeders/StarterSeeder.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\ResourceOwnership;
+use App\Models\Announcement;
+use App\Models\Room;
+use App\Models\ScheduleEntry;
+use App\Models\Screen;
+use App\Models\Project;
+use App\Settings\GeneralSettings;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class StarterSeeder extends Seeder
+{
+    /**
+     * Seed a generic "Starter" demo so a fresh clone running
+     * `php artisan migrate --seed` gets a working demo screen at
+     * `/screens/demo` playing a small playlist of example designs.
+     */
+    public function run(): void
+    {
+        $project = Project::updateOrCreate([
+            'path' => 'Starter',
+        ], [
+            'name' => 'Starter',
+            'path' => 'Starter',
+            'type' => ResourceOwnership::USER,
+        ]);
+
+        /**
+         * Pages (example designs). The matching Vue components are created
+         * separately; here we only register the database records + schema.
+         * Schema entries follow the shape used elsewhere:
+         * ["name" => .., "property" => .., "type" => "TextInput"].
+         */
+        $welcomePage = $project->pages()->updateOrCreate([
+            'component' => 'Welcome',
+        ], [
+            'name' => 'Welcome',
+            'component' => 'Welcome',
+            'schema' => [
+                [
+                    'name' => 'Title',
+                    'property' => 'title',
+                    'type' => 'TextInput',
+                ],
+                [
+                    'name' => 'Subtitle',
+                    'property' => 'subtitle',
+                    'type' => 'TextInput',
+                ],
+            ],
+        ]);
+
+        $scheduleBoardPage = $project->pages()->updateOrCreate([
+            'component' => 'ScheduleBoard',
+        ], [
+            'name' => 'Schedule Board',
+            'component' => 'ScheduleBoard',
+            'schema' => [
+                [
+                    'name' => 'Title',
+                    'property' => 'title',
+                    'type' => 'TextInput',
+                ],
+            ],
+        ]);
+
+        $announcementsPage = $project->pages()->updateOrCreate([
+            'component' => 'Announcements',
+        ], [
+            'name' => 'Announcements',
+            'component' => 'Announcements',
+            'schema' => [
+                [
+                    'name' => 'Title',
+                    'property' => 'title',
+                    'type' => 'TextInput',
+                ],
+            ],
+        ]);
+
+        $roomGridPage = $project->pages()->updateOrCreate([
+            'component' => 'RoomGrid',
+        ], [
+            'name' => 'Room Grid',
+            'component' => 'RoomGrid',
+            'schema' => [],
+        ]);
+
+        /**
+         * Layouts.
+         */
+        $gridLayout = $project->layouts()->updateOrCreate([
+            'component' => 'Grid',
+        ], [
+            'name' => 'Grid',
+            'component' => 'Grid',
+        ]);
+
+        $noneLayout = $project->layouts()->updateOrCreate([
+            'component' => 'None',
+        ], [
+            'name' => 'None',
+            'component' => 'None',
+        ]);
+
+        /**
+         * Playlist + items. `content` provides the schema props the Vue
+         * components receive (keys must match the page `property` names).
+         */
+        $playlist = $project->playlists()->firstOrCreate([
+            'name' => 'Starter Demo',
+        ]);
+
+        $items = [
+            [
+                'page_id' => $welcomePage->id,
+                'layout_id' => $gridLayout->id,
+                'title' => 'Welcome',
+                'duration' => 15,
+                'sort' => 1,
+                'content' => [
+                    'title' => 'Welcome to Open Signage',
+                    'subtitle' => 'Build signage designs, fast',
+                ],
+            ],
+            [
+                'page_id' => $scheduleBoardPage->id,
+                'layout_id' => $gridLayout->id,
+                'title' => 'Schedule Board',
+                'duration' => 15,
+                'sort' => 2,
+                'content' => [
+                    'title' => "What's On",
+                ],
+            ],
+            [
+                'page_id' => $roomGridPage->id,
+                'layout_id' => $gridLayout->id,
+                'title' => 'Room Grid',
+                'duration' => 15,
+                'sort' => 3,
+                'content' => [],
+            ],
+            [
+                'page_id' => $announcementsPage->id,
+                'layout_id' => $noneLayout->id,
+                'title' => 'Announcements',
+                'duration' => 15,
+                'sort' => 4,
+                'content' => [
+                    'title' => 'Announcements',
+                ],
+            ],
+        ];
+
+        foreach ($items as $item) {
+            $playlist->playlistItems()->updateOrCreate([
+                'page_id' => $item['page_id'],
+                'layout_id' => $item['layout_id'],
+            ], [
+                'title' => $item['title'],
+                'duration' => $item['duration'],
+                'sort' => $item['sort'],
+                'is_active' => true,
+                'content' => $item['content'],
+            ]);
+        }
+
+        /**
+         * Demo rooms.
+         */
+        $roomNames = ['Main Stage', 'Workshop A', 'Workshop B', 'Lounge', 'Info Desk'];
+        $rooms = collect($roomNames)->map(fn (string $name) => Room::updateOrCreate(
+            ['name' => $name],
+            ['name' => $name],
+        ));
+
+        /**
+         * Demo schedule entries spread across today. `flags` is a
+         * non-nullable json column, so it is always provided; `delay` is set
+         * on a couple of entries. `room_id` is required.
+         */
+        $today = Carbon::today();
+        $titles = [
+            'Opening Keynote',
+            'Coffee & Networking',
+            'Intro Workshop',
+            'Hands-on Lab',
+            'Panel Discussion',
+            'Lunch Break',
+            'Lightning Talks',
+            'Deep Dive Session',
+            'Community Meetup',
+            'Closing Remarks',
+        ];
+
+        foreach ($titles as $index => $title) {
+            $start = $today->copy()->addHours(9 + $index);
+            $room = $rooms[$index % $rooms->count()];
+
+            ScheduleEntry::updateOrCreate([
+                'title' => $title,
+                'room_id' => $room->id,
+            ], [
+                'title' => $title,
+                'room_id' => $room->id,
+                'starts_at' => $start,
+                'ends_at' => $start->copy()->addMinutes(50),
+                'flags' => [],
+                'delay' => in_array($index, [2, 6]) ? 15 : 0,
+            ]);
+        }
+
+        /**
+         * Demo announcements.
+         */
+        $announcements = [
+            [
+                'title' => 'Welcome!',
+                'content' => 'Welcome to the Open Signage starter demo.',
+            ],
+            [
+                'title' => 'Wifi',
+                'content' => 'Connect to the "OpenSignage" network. No password required.',
+            ],
+            [
+                'title' => 'Help Desk',
+                'content' => 'Visit the Info Desk for any assistance.',
+            ],
+        ];
+
+        foreach ($announcements as $announcement) {
+            Announcement::updateOrCreate([
+                'title' => $announcement['title'],
+            ], [
+                'title' => $announcement['title'],
+                'content' => $announcement['content'],
+                'starts_at' => $today->copy()->startOfDay(),
+                'ends_at' => $today->copy()->endOfDay(),
+            ]);
+        }
+
+        /**
+         * Demo screen at /screens/demo.
+         */
+        $screen = Screen::updateOrCreate([
+            'slug' => 'demo',
+        ], [
+            'name' => 'Demo Screen',
+            'slug' => 'demo',
+            'playlist_id' => $playlist->id,
+            'provisioned' => true,
+        ]);
+
+        // Attach demo rooms with pivot sort order (other pivot fields use
+        // their column defaults / nullable values).
+        $screen->rooms()->sync(
+            $rooms->mapWithKeys(fn (Room $room, int $index) => [
+                $room->id => ['sort' => $index],
+            ])->all()
+        );
+
+        /**
+         * Make the Starter Demo playlist the default for newly auto-created
+         * screens. SystemSeeder runs first and only sets this when empty
+         * (pointing at the Screen Identification playlist); for a clean demo
+         * we explicitly override it so the demo is what shows by default.
+         */
+        $settings = app(GeneralSettings::class);
+        $settings->playlist_id = $playlist->id;
+        $settings->save();
+    }
+}

--- a/database/seeders/StarterSeeder.php
+++ b/database/seeders/StarterSeeder.php
@@ -4,10 +4,10 @@ namespace Database\Seeders;
 
 use App\Enums\ResourceOwnership;
 use App\Models\Announcement;
+use App\Models\Project;
 use App\Models\Room;
 use App\Models\ScheduleEntry;
 use App\Models\Screen;
-use App\Models\Project;
 use App\Settings\GeneralSettings;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,163 @@
+# Developing designs with Open Signage
+
+Open Signage is a **framework for building digital‑signage designs**. You write
+your screens as Vue 3 components in a *project*, preview them instantly in the
+browser with mock data, and the platform handles playlists, scheduling, live
+updates and kiosk delivery.
+
+This guide gets you from a fresh clone to iterating on your own design as fast
+as possible.
+
+---
+
+## 1. Quick start
+
+```bash
+git clone https://github.com/thiritin/open-signage.git
+cd open-signage
+
+composer install
+npm install
+
+cp .env.example .env
+php artisan key:generate
+
+# Create the schema and seed a working demo (a "demo" screen, a Starter
+# playlist, rooms, schedule and announcements):
+php artisan migrate --seed
+
+# Two terminals (or use Laravel Sail):
+php artisan serve      # http://localhost:8000
+npm run dev            # Vite dev server with hot reload
+```
+
+Now open:
+
+| URL | What you get |
+| --- | --- |
+| `http://localhost:8000/preview` | **Design preview** – render any design with mock data, no DB needed |
+| `http://localhost:8000/screens/demo` | The seeded demo screen running the real playlist pipeline |
+| `http://localhost:8000/admin` | Filament admin (login `me@thiritin.com` / `password`) |
+
+> The active project is selected with `VITE_PROJECT_PATH` in `.env`
+> (default: `Starter`). It is baked in at build time, so change it and restart
+> Vite to switch projects.
+
+---
+
+## 2. The preview workflow (test designs without any setup)
+
+The fastest way to iterate on a design is the **preview route**. It renders a
+single design component standalone, fed with realistic **mock data** from
+`resources/js/mock/index.js` — **no database, no playlist, no screen, no
+websocket server required.**
+
+```
+/preview                         # first design, default layout
+/preview/RoomGrid                # preview a specific page component
+/preview/ScheduleBoard?layout=Grid
+/preview/Welcome?layout=Grid&bare=1   # bare=1 hides the dev toolbar (clean screenshots)
+```
+
+The preview screen has a small **dev toolbar** to switch page, switch layout,
+change the canvas resolution (1080p / 4K / portrait / 720p) and toggle a grid
+overlay. It is **dev‑only** (gated behind `APP_DEBUG`/`local`).
+
+Edit your `.vue` file → Vite hot‑reloads → see it instantly. Tweak the mock data
+in `resources/js/mock/index.js` to exercise edge cases.
+
+---
+
+## 3. Anatomy of a project
+
+A project is a folder under `resources/js/Projects/<Name>/`:
+
+```
+resources/js/Projects/Starter/
+├── app.css          # global styles (imported automatically for the active project)
+├── theme.js         # Tailwind theme (colors etc.) – merged into tailwind.config.js
+├── Layouts/         # frames that wrap pages (background, scaling, transitions)
+│   ├── Grid.vue
+│   └── None.vue
+├── Pages/           # the actual designs
+│   ├── Welcome.vue
+│   ├── ScheduleBoard.vue
+│   ├── RoomGrid.vue
+│   └── Announcements.vue
+└── Components/      # shared bits used by your pages
+    └── Clock.vue
+```
+
+**Every page receives the same screen data as props**, forwarded by its layout:
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `appScreen` | Object | The screen (name, slug, orientation, `rooms`, …) |
+| `rooms` | Array | Rooms assigned to the screen (each with a `pivot`) |
+| `schedule` | Array | Schedule entries (`title`, `room`, `starts_at`, `ends_at`, `delay`, …) |
+| `announcements` | Array | Active announcements |
+| `artworks` | Array | Artwork gallery items |
+| `connected` | Boolean | Websocket connection state |
+
+…plus any **page‑specific props** you declare in the page's *schema* (editable in
+the admin and stored per playlist item) — e.g. `title`, `subtitle`.
+
+To register a new page/layout in the database (so it can be added to playlists),
+mirror `database/seeders/StarterSeeder.php`.
+
+---
+
+## 4. The grid system (auto‑fit + scale‑to‑fit)
+
+Signage screens come in every resolution. Instead of hand‑tuning a design for
+1080p, **author against a fixed virtual canvas and let the framework scale it to
+fit any screen** — and never larger than the screen. Three primitives in
+`resources/js/Components/Grid/` make this work:
+
+- **`AutoScale`** – wraps your design in a fixed virtual canvas (default
+  `1920×1080`) and uniformly scales it to fit the viewport (`contain`). This is
+  the "never larger than the screen" guarantee. The Starter layouts already do
+  this for you.
+- **`Grid`** – a CSS‑grid container that *fills* its parent. Every track is
+  `minmax(0, 1fr)`, so adding more blocks just makes each smaller — the grid
+  **auto‑extends but never overflows**. Use `auto-fit` to arrange N blocks into a
+  near‑square grid automatically.
+- **`Block`** – a tile that spans `colSpan × rowSpan` cells, with optional
+  `title`, `fit`, and `align`.
+- **`FitText`** – shrinks content so it never overflows its tile (used via the
+  `fit` prop on `Block`, or directly).
+
+```vue
+<script setup>
+import { AutoScale, Grid, Block } from "@/Components/Grid";
+defineProps({ rooms: { type: Array, default: () => [] } });
+</script>
+
+<template>
+  <!-- The Starter layouts already provide AutoScale; shown here for clarity. -->
+  <AutoScale :width="1920" :height="1080" mode="contain">
+    <Grid auto-fit gap="1.5rem">
+      <Block v-for="r in rooms" :key="r.id" fit align="center">
+        {{ r.name }}
+      </Block>
+    </Grid>
+  </AutoScale>
+</template>
+```
+
+See `resources/js/Components/Grid/README.md` for the full prop reference and
+`resources/js/Projects/Starter/Pages/RoomGrid.vue` for a complete example.
+
+---
+
+## 5. Creating your own project
+
+1. Copy `resources/js/Projects/Starter` to `resources/js/Projects/MyProject`.
+2. Set `VITE_PROJECT_PATH="MyProject"` in `.env` and restart Vite.
+3. Build your pages/layouts under `Pages/` and `Layouts/`, previewing with
+   `/preview`.
+4. Add a seeder (copy `StarterSeeder.php`) to register your pages/layouts and a
+   demo playlist, so designs become selectable in the admin and on real screens.
+
+Keep event‑ or customer‑specific projects in **their own repository** and drop
+the folder into `resources/js/Projects/` — the framework stays generic.

--- a/resources/js/Components/Grid/AutoScale.vue
+++ b/resources/js/Components/Grid/AutoScale.vue
@@ -1,0 +1,61 @@
+<script setup>
+// AutoScale.vue
+//
+// Wraps a default slot in a fixed "virtual canvas" of width x height px and
+// scales it to fit the real viewport using `useScaleToFit`. This is the
+// guarantee that signage designs are resolution-independent and "never larger
+// than the screen": author against a 1920x1080 canvas, render on any display.
+//
+// The outer wrapper fills the viewport (100vw x 100vh), hides overflow and
+// centers the canvas. The inner canvas is exactly width x height px and is
+// transform-scaled to fit.
+
+import { ref } from 'vue'
+import { useScaleToFit } from './useScaleToFit.js'
+
+const props = defineProps({
+    // Virtual canvas dimensions (px) the design is authored against.
+    width: { type: Number, default: 1920 },
+    height: { type: Number, default: 1080 },
+    // Fit strategy: 'contain' | 'cover' | 'fit-width' | 'fit-height' | 'stretch'.
+    mode: { type: String, default: 'contain' },
+    // Background color of the viewport area (letterbox bars in 'contain').
+    background: { type: String, default: 'transparent' },
+})
+
+const canvas = ref(null)
+
+const { style } = useScaleToFit(canvas, {
+    width: () => props.width,
+    height: () => props.height,
+    mode: () => props.mode,
+})
+</script>
+
+<template>
+    <div class="autoscale-viewport" :style="{ background }">
+        <!-- Fixed virtual canvas; transform-scaled to fit the viewport. -->
+        <div ref="canvas" class="autoscale-canvas" :style="style">
+            <slot />
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.autoscale-viewport {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.autoscale-canvas {
+    /* width/height/transform are supplied by the bound :style. */
+    position: relative;
+    flex: 0 0 auto;
+}
+</style>

--- a/resources/js/Components/Grid/Block.vue
+++ b/resources/js/Components/Grid/Block.vue
@@ -1,0 +1,112 @@
+<script setup>
+// Block.vue
+//
+// A single grid tile/cell. It places itself in the parent Grid via
+// `grid-column: span colSpan` / `grid-row: span rowSpan`, and renders a subtle,
+// neutral, overridable tile surface. Optionally fits its content with FitText
+// so a tile's content never overflows the cell.
+//
+// Span clamping: if a parent Grid provided its resolved column count, colSpan is
+// clamped to it so a tile can never be wider than the grid's row.
+
+import { computed, inject } from 'vue'
+import FitText from './FitText.vue'
+import { GRID_COLUMNS_KEY } from './gridKeys.js'
+
+const props = defineProps({
+    // How many columns this tile spans.
+    colSpan: { type: Number, default: 1 },
+    // How many rows this tile spans.
+    rowSpan: { type: Number, default: 1 },
+    // Optional header text rendered above the content (overridden by #header).
+    title: { type: String, default: '' },
+    // Inner padding of the tile.
+    padding: { type: String, default: '1.5rem' },
+    // When true, wrap the default slot in FitText so content auto-shrinks.
+    fit: { type: Boolean, default: false },
+    // Content alignment inside the tile: 'stretch' | 'start' | 'center' | 'end'.
+    align: { type: String, default: 'stretch' },
+})
+
+// Provided by the nearest Grid (a Ref<number>), or undefined if standalone.
+const gridColumns = inject(GRID_COLUMNS_KEY, null)
+
+// Clamp colSpan to [1, columns] when a column count is available.
+const effectiveColSpan = computed(() => {
+    const span = Math.max(1, props.colSpan)
+    const max = gridColumns && gridColumns.value ? gridColumns.value : null
+    return max ? Math.min(span, max) : span
+})
+
+const effectiveRowSpan = computed(() => Math.max(1, props.rowSpan))
+
+const tileStyle = computed(() => ({
+    gridColumn: `span ${effectiveColSpan.value}`,
+    gridRow: `span ${effectiveRowSpan.value}`,
+    padding: props.padding,
+}))
+
+// Map align prop to flexbox alignment for the content column.
+const contentAlign = computed(() => {
+    switch (props.align) {
+        case 'start':
+            return { justifyContent: 'flex-start', alignItems: 'flex-start' }
+        case 'center':
+            return { justifyContent: 'center', alignItems: 'center' }
+        case 'end':
+            return { justifyContent: 'flex-end', alignItems: 'flex-end' }
+        case 'stretch':
+        default:
+            return { justifyContent: 'flex-start', alignItems: 'stretch' }
+    }
+})
+</script>
+
+<template>
+    <!-- Neutral, overridable surface. Override bg/rounding via class on usage. -->
+    <div class="block-tile rounded-2xl bg-white/5" :style="tileStyle">
+        <!-- Header: #header slot wins, else `title` prop if present. -->
+        <header v-if="$slots.header || title" class="block-header">
+            <slot name="header">{{ title }}</slot>
+        </header>
+
+        <!-- Content region fills remaining space. -->
+        <div class="block-content" :style="contentAlign">
+            <FitText v-if="fit">
+                <slot />
+            </FitText>
+            <template v-else>
+                <slot />
+            </template>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.block-tile {
+    display: flex;
+    flex-direction: column;
+    /* min-* lets the tile shrink within minmax(0,1fr) tracks. */
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+
+.block-header {
+    flex: 0 0 auto;
+    margin-bottom: 0.75rem;
+    font-weight: 600;
+    line-height: 1.1;
+}
+
+.block-content {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    /* When fit is used, FitText fills this box and measures against it. */
+    overflow: hidden;
+}
+</style>

--- a/resources/js/Components/Grid/FitText.vue
+++ b/resources/js/Components/Grid/FitText.vue
@@ -1,0 +1,134 @@
+<script setup>
+// FitText.vue
+//
+// Shrinks its slot content (via CSS transform: scale) so it NEVER overflows its
+// container in either dimension. This is the "fit-to-content" leg of the system:
+// the virtual canvas keeps the layout fixed, the grid keeps tiles bounded, and
+// FitText keeps content inside each tile no matter how big it naturally is.
+//
+// Algorithm: measure the container box and the content's natural box, then
+// scale = min(max, containerW/contentW, containerH/contentH), clamped to >= min.
+// transform-origin is top-left so the scaled content stays anchored.
+//
+// Recomputes on container resize (ResizeObserver) and content change
+// (MutationObserver), and measures inside requestAnimationFrame after layout.
+
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+const props = defineProps({
+    // Maximum scale (never enlarge content beyond this).
+    max: { type: Number, default: 1 },
+    // Minimum scale (floor so content never vanishes entirely).
+    min: { type: Number, default: 0.1 },
+})
+
+const container = ref(null) // the clipping box we must fit within
+const content = ref(null)   // the natural-size wrapper we scale
+const scale = ref(1)
+
+let resizeObserver = null
+let mutationObserver = null
+let rafId = null
+
+function measure() {
+    rafId = null
+    const c = container.value
+    const inner = content.value
+    if (!c || !inner) return
+
+    const cw = c.clientWidth
+    const ch = c.clientHeight
+
+    // Natural (unscaled) content size. scrollWidth/Height reflect the content
+    // box; we temporarily ignore the current transform by reading offset size,
+    // which is layout size before transform is applied.
+    const contentW = inner.offsetWidth
+    const contentH = inner.offsetHeight
+
+    // Guard against divide-by-zero / not-yet-laid-out elements.
+    if (cw <= 0 || ch <= 0 || contentW <= 0 || contentH <= 0) {
+        return
+    }
+
+    let next = Math.min(props.max, cw / contentW, ch / contentH)
+    if (!Number.isFinite(next)) next = props.max
+    next = Math.max(props.min, next)
+    scale.value = next
+}
+
+function scheduleMeasure() {
+    if (rafId != null) return
+    rafId = requestAnimationFrame(measure)
+}
+
+onMounted(() => {
+    scheduleMeasure()
+
+    if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(scheduleMeasure)
+        if (container.value) resizeObserver.observe(container.value)
+        // Also observe the content so intrinsic size changes are caught.
+        if (content.value) resizeObserver.observe(content.value)
+    }
+
+    if (typeof MutationObserver !== 'undefined' && content.value) {
+        mutationObserver = new MutationObserver(scheduleMeasure)
+        mutationObserver.observe(content.value, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+            attributes: true,
+        })
+    }
+
+    window.addEventListener('resize', scheduleMeasure, { passive: true })
+})
+
+onBeforeUnmount(() => {
+    if (resizeObserver) {
+        resizeObserver.disconnect()
+        resizeObserver = null
+    }
+    if (mutationObserver) {
+        mutationObserver.disconnect()
+        mutationObserver = null
+    }
+    window.removeEventListener('resize', scheduleMeasure)
+    if (rafId != null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+    }
+})
+</script>
+
+<template>
+    <div ref="container" class="fittext-container">
+        <!-- The content is measured at its natural size, then scaled. -->
+        <div
+            ref="content"
+            class="fittext-content"
+            :style="{ transform: `scale(${scale})`, transformOrigin: 'top left' }"
+        >
+            <slot />
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.fittext-container {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+}
+
+.fittext-content {
+    /* Lay out at natural width so we can measure the true content size, then
+       shrink via transform. inline-block hugs the content box. */
+    display: inline-block;
+    white-space: normal;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+</style>

--- a/resources/js/Components/Grid/Grid.vue
+++ b/resources/js/Components/Grid/Grid.vue
@@ -1,0 +1,132 @@
+<script setup>
+// Grid.vue
+//
+// A CSS-grid container that FILLS its parent (100% x 100%). It is the layout
+// backbone of the signage system. The critical trick is `minmax(0, 1fr)` for
+// every track: rows and columns share the available space equally and the grid
+// NEVER exceeds its container. Adding more blocks simply makes each smaller —
+// "auto extends, never larger than the screen".
+//
+// Two modes:
+//   * Explicit: `columns` columns (default 12), rows 'auto' or a fixed count.
+//   * autoFit:  ignores `columns` and arranges the N children into a near-square
+//               grid (cols = ceil(sqrt(N)), rows = ceil(N/cols)), each equal.
+//
+// The resolved column count is provided to descendant Blocks (via provide) so
+// they can clamp their colSpan and never overflow a row.
+
+import { computed, provide, useSlots } from 'vue'
+import { GRID_COLUMNS_KEY } from './gridKeys.js'
+
+const props = defineProps({
+    // Number of columns when autoFit is false.
+    columns: { type: Number, default: 12 },
+    // 'auto' lets rows grow with content (grid-auto-rows), or fix a row count.
+    rows: { type: [Number, String], default: 'auto' },
+    // Gap between tiles (any CSS length).
+    gap: { type: String, default: '1.5rem' },
+    // When true, ignore `columns` and auto-arrange children into a square-ish grid.
+    autoFit: { type: Boolean, default: false },
+    // Inner padding of the grid container.
+    padding: { type: String, default: '0' },
+})
+
+const slots = useSlots()
+
+// Count the rendered top-level VNodes of the default slot. We flatten obvious
+// container fragments (v-for / template) so `<Block v-for>` is counted per item.
+function countSlotChildren() {
+    const nodes = slots.default ? slots.default() : []
+    let count = 0
+    const visit = (list) => {
+        for (const vnode of list) {
+            if (vnode == null) continue
+            // Comment nodes (e.g. v-if placeholders) have Symbol type — skip.
+            if (typeof vnode.type === 'symbol') {
+                // Fragment: its children is an array of vnodes (v-for output).
+                if (Array.isArray(vnode.children)) {
+                    visit(vnode.children)
+                }
+                continue
+            }
+            // Skip plain whitespace text nodes.
+            if (typeof vnode.children === 'string' && vnode.children.trim() === '') {
+                continue
+            }
+            count++
+        }
+    }
+    visit(nodes)
+    return count
+}
+
+// Reactive child count (re-evaluated when the slot re-renders).
+const childCount = computed(() => countSlotChildren())
+
+// autoFit geometry: near-square arrangement of childCount items.
+const autoCols = computed(() => {
+    const n = childCount.value
+    return n > 0 ? Math.ceil(Math.sqrt(n)) : 1
+})
+const autoRows = computed(() => {
+    const n = childCount.value
+    const cols = autoCols.value
+    return n > 0 ? Math.ceil(n / cols) : 1
+})
+
+// The effective column count, provided to Blocks for span-clamping.
+const resolvedColumns = computed(() =>
+    props.autoFit ? autoCols.value : props.columns
+)
+provide(GRID_COLUMNS_KEY, resolvedColumns)
+
+const gridStyle = computed(() => {
+    const base = {
+        display: 'grid',
+        width: '100%',
+        height: '100%',
+        gap: props.gap,
+        padding: props.padding,
+        boxSizing: 'border-box',
+    }
+
+    if (props.autoFit) {
+        // Equal square-ish cells; every child sized equally.
+        return {
+            ...base,
+            gridTemplateColumns: `repeat(${autoCols.value}, minmax(0, 1fr))`,
+            gridTemplateRows: `repeat(${autoRows.value}, minmax(0, 1fr))`,
+        }
+    }
+
+    // Explicit columns. minmax(0, 1fr) keeps tracks equal and prevents overflow.
+    const out = {
+        ...base,
+        gridTemplateColumns: `repeat(${props.columns}, minmax(0, 1fr))`,
+    }
+
+    if (props.rows === 'auto' || props.rows == null) {
+        // Rows grow as needed but each shares space equally.
+        out.gridAutoRows = 'minmax(0, 1fr)'
+    } else {
+        // Fixed number of equal rows that fill the container height.
+        out.gridTemplateRows = `repeat(${props.rows}, minmax(0, 1fr))`
+    }
+
+    return out
+})
+</script>
+
+<template>
+    <div class="grid-container" :style="gridStyle">
+        <slot />
+    </div>
+</template>
+
+<style scoped>
+.grid-container {
+    /* min-height/width:0 lets the grid shrink inside flex/grid parents. */
+    min-width: 0;
+    min-height: 0;
+}
+</style>

--- a/resources/js/Components/Grid/README.md
+++ b/resources/js/Components/Grid/README.md
@@ -1,0 +1,140 @@
+# Open Signage — Grid System
+
+An Alamos FE2–style auto-fitting **GRID / BLOCK** system for composing
+full-screen digital-signage designs that **always fit the screen and never
+overflow**, regardless of the physical display resolution.
+
+## Design philosophy
+
+Three independent mechanisms stack to make overflow impossible:
+
+1. **Virtual canvas (`AutoScale`)** — You author every design against a fixed
+   virtual canvas (default `1920 × 1080`). `AutoScale` measures the real
+   viewport and applies a single CSS `transform: scale()` so the canvas fits the
+   screen. Layout math never depends on the actual resolution — design once,
+   render on a 4K wall or a 720p panel identically.
+
+2. **Auto-fit grid (`Grid` + `Block`)** — A CSS grid where every track is
+   `minmax(0, 1fr)`. Columns and rows always share the available space equally,
+   so the grid **can never exceed its container**. Adding more blocks simply
+   makes each block smaller. With `auto-fit`, N blocks are arranged into a
+   near-square grid automatically.
+
+3. **Fit-to-content (`FitText`)** — Inside a block, content is measured and
+   shrunk (`transform: scale()`) so it never overflows its cell in either
+   dimension — no matter how long the text or how big the element.
+
+> Virtual canvas + auto-fit grid + fit-to-content = **never overflows.**
+
+## Full example
+
+```vue
+<script setup>
+import { AutoScale, Grid, Block } from '@/Components/Grid'
+</script>
+
+<template>
+  <AutoScale :width="1920" :height="1080" mode="contain" background="#0b1020">
+    <Grid :columns="12" gap="1.5rem" padding="2rem">
+      <Block :col-span="8" :row-span="2" title="Now" fit>
+        <div class="text-white text-9xl font-bold">Main Hall — Keynote</div>
+      </Block>
+      <Block :col-span="4" title="Up Next">
+        <p class="text-white text-4xl">Workshop A · 14:30</p>
+      </Block>
+      <Block :col-span="12" align="center">
+        <span class="text-white/70 text-3xl">Welcome to the conference</span>
+      </Block>
+    </Grid>
+  </AutoScale>
+</template>
+```
+
+### Auto-fit mode (near-square grid from a list)
+
+```vue
+<AutoScale>
+  <Grid auto-fit gap="1rem" padding="1.5rem">
+    <Block v-for="r in rooms" :key="r.id" :title="r.name" fit>
+      {{ r.status }}
+    </Block>
+  </Grid>
+</AutoScale>
+```
+
+`auto-fit` ignores `columns` and arranges the N blocks into
+`cols = ceil(sqrt(N))` × `rows = ceil(N / cols)`, sizing every block equally.
+
+## Component reference
+
+### `AutoScale`
+
+Wraps a slot in a fixed virtual canvas and scales it to fit the viewport.
+
+| Prop         | Type     | Default         | Description |
+|--------------|----------|-----------------|-------------|
+| `width`      | `Number` | `1920`          | Virtual canvas width (px) the design is authored against. |
+| `height`     | `Number` | `1080`          | Virtual canvas height (px). |
+| `mode`       | `String` | `'contain'`     | Fit strategy (see below). |
+| `background` | `String` | `'transparent'` | Viewport background (letterbox bars in `contain`). |
+
+**`mode` values:**
+
+- `contain` — fit entirely within the viewport, preserve aspect ratio, never
+  larger than the screen (`min(vw/w, vh/h)`). **Default / safest.**
+- `cover` — fill the whole viewport, preserve aspect ratio, may crop (`max(...)`).
+- `fit-width` — match viewport width; height scales with it.
+- `fit-height` — match viewport height; width scales with it.
+- `stretch` — fill both axes independently (aspect ratio not preserved).
+
+### `Grid`
+
+CSS-grid container that fills its parent (`100% × 100%`).
+
+| Prop      | Type            | Default    | Description |
+|-----------|-----------------|------------|-------------|
+| `columns` | `Number`        | `12`       | Column count (ignored when `auto-fit`). |
+| `rows`    | `Number｜String` | `'auto'`   | `'auto'` grows rows with content; a number fixes equal rows. |
+| `gap`     | `String`        | `'1.5rem'` | Gap between tiles (any CSS length). |
+| `autoFit` | `Boolean`       | `false`    | Auto-arrange children into a near-square grid; ignores `columns`. |
+| `padding` | `String`        | `'0'`      | Inner padding of the grid container. |
+
+Provides its resolved column count to descendant `Block`s for span clamping.
+
+### `Block`
+
+A single grid tile.
+
+| Prop      | Type     | Default    | Description |
+|-----------|----------|------------|-------------|
+| `colSpan` | `Number` | `1`        | Columns to span (clamped to the Grid's column count). |
+| `rowSpan` | `Number` | `1`        | Rows to span. |
+| `title`   | `String` | `''`       | Header text above the content (overridden by `#header`). |
+| `padding` | `String` | `'1.5rem'` | Inner padding of the tile. |
+| `fit`     | `Boolean`| `false`    | Wrap content in `FitText` so it auto-shrinks to fit. |
+| `align`   | `String` | `'stretch'`| Content alignment: `stretch｜start｜center｜end`. |
+
+**Slots:** default (content), `#header` (overrides `title`).
+
+The default surface is `rounded-2xl bg-white/5` — override by adding your own
+background/rounding classes on the `<Block>` usage.
+
+### `FitText`
+
+Shrinks its slot content so it never overflows its container.
+
+| Prop  | Type     | Default | Description |
+|-------|----------|---------|-------------|
+| `max` | `Number` | `1`     | Maximum scale (never enlarges beyond this). |
+| `min` | `Number` | `0.1`   | Minimum scale floor. |
+
+Recomputes on container resize (`ResizeObserver`) and content change
+(`MutationObserver`). `scale = min(max, containerW/contentW, containerH/contentH)`,
+clamped to `min`.
+
+### `useScaleToFit(targetRef, { width, height, mode })`
+
+Low-level composable powering `AutoScale`. Returns `{ scale, scaleX, scaleY, style }`
+— reactive scale factors plus a computed `style` object (`width`, `height`,
+`transform`, `transformOrigin`) to bind to the canvas element. Each option may be
+a raw value or a getter/ref (reactive). Cleans up its observers on unmount.

--- a/resources/js/Components/Grid/gridKeys.js
+++ b/resources/js/Components/Grid/gridKeys.js
@@ -1,0 +1,8 @@
+// gridKeys.js
+//
+// Shared provide/inject keys for the Grid system. Kept in a tiny module so both
+// Grid.vue (provider) and Block.vue (consumer) reference the exact same symbol.
+
+// The resolved column count of the nearest Grid ancestor (a Ref<number>).
+// Blocks use this to clamp their colSpan so a tile never overflows a row.
+export const GRID_COLUMNS_KEY = Symbol('grid-columns')

--- a/resources/js/Components/Grid/index.js
+++ b/resources/js/Components/Grid/index.js
@@ -1,0 +1,12 @@
+// index.js
+//
+// Barrel module for the Open Signage Grid system. Import everything from here:
+//
+//   import { AutoScale, Grid, Block, FitText, useScaleToFit } from '@/Components/Grid'
+
+export { default as AutoScale } from './AutoScale.vue'
+export { default as Grid } from './Grid.vue'
+export { default as Block } from './Block.vue'
+export { default as FitText } from './FitText.vue'
+
+export { useScaleToFit } from './useScaleToFit.js'

--- a/resources/js/Components/Grid/useScaleToFit.js
+++ b/resources/js/Components/Grid/useScaleToFit.js
@@ -1,0 +1,151 @@
+// useScaleToFit.js
+//
+// A composable that computes a CSS transform scale so a fixed "virtual canvas"
+// (width x height, in px) always fits the real viewport, regardless of the
+// physical screen resolution. This is the core of the resolution-independent
+// signage system: design once against a virtual canvas, render anywhere.
+//
+// Usage:
+//   const target = ref(null)
+//   const { scale, style } = useScaleToFit(target, { width: 1920, height: 1080, mode: 'contain' })
+//
+// The `style` computed is meant to be bound to the virtual-canvas element.
+
+import { ref, computed, unref, onMounted, onBeforeUnmount, watch } from 'vue'
+
+/**
+ * @param {import('vue').Ref<HTMLElement|null>} targetRef - the canvas element to scale.
+ * @param {Object} options
+ * @param {number|import('vue').Ref<number>} options.width  - virtual canvas width in px.
+ * @param {number|import('vue').Ref<number>} options.height - virtual canvas height in px.
+ * @param {string|import('vue').Ref<string>} options.mode   - 'contain' | 'cover' | 'fit-width' | 'fit-height' | 'stretch'.
+ * @returns {{ scale: import('vue').Ref<number>, scaleX: import('vue').Ref<number>, scaleY: import('vue').Ref<number>, style: import('vue').ComputedRef<Object> }}
+ */
+export function useScaleToFit(targetRef, options = {}) {
+    // Independent X/Y scale factors. For uniform modes scaleX === scaleY.
+    const scaleX = ref(1)
+    const scaleY = ref(1)
+    // Convenience uniform scale (equals scaleX for non-stretch modes).
+    const scale = ref(1)
+
+    let resizeObserver = null
+
+    const getWidth = () => Number(unref(options.width)) || 1920
+    const getHeight = () => Number(unref(options.height)) || 1080
+    const getMode = () => unref(options.mode) || 'contain'
+
+    function compute() {
+        const width = getWidth()
+        const height = getHeight()
+        if (width <= 0 || height <= 0) return
+
+        // Measure the real viewport. We prefer the documentElement client size
+        // (the kiosk Chrome window) and fall back to window inner size.
+        const root = document.documentElement
+        const vw = (root && root.clientWidth) || window.innerWidth || 0
+        const vh = (root && root.clientHeight) || window.innerHeight || 0
+        if (vw <= 0 || vh <= 0) return
+
+        const sw = vw / width   // scale needed to fill width
+        const sh = vh / height  // scale needed to fill height
+
+        let sx
+        let sy
+
+        switch (getMode()) {
+            case 'cover':
+                // Fill the entire viewport; canvas may be cropped. Uniform.
+                sx = sy = Math.max(sw, sh)
+                break
+            case 'fit-width':
+                // Match the viewport width; height scales uniformly with it.
+                sx = sy = sw
+                break
+            case 'fit-height':
+                // Match the viewport height; width scales uniformly with it.
+                sx = sy = sh
+                break
+            case 'stretch':
+                // Independently fill both axes (aspect ratio not preserved).
+                sx = sw
+                sy = sh
+                break
+            case 'contain':
+            default:
+                // Fit entirely within the viewport, never larger than the
+                // screen, preserving aspect ratio. This is the safe default.
+                sx = sy = Math.min(sw, sh)
+                break
+        }
+
+        scaleX.value = sx
+        scaleY.value = sy
+        // Uniform reference scale (for callers that only need one number).
+        scale.value = getMode() === 'stretch' ? Math.min(sx, sy) : sx
+    }
+
+    // requestAnimationFrame guards against measuring mid-layout.
+    let rafId = null
+    function scheduleCompute() {
+        if (rafId != null) return
+        rafId = requestAnimationFrame(() => {
+            rafId = null
+            compute()
+        })
+    }
+
+    onMounted(() => {
+        compute()
+
+        // ResizeObserver on the document root catches viewport changes that a
+        // plain 'resize' event might miss (e.g. zoom, devtools, container size).
+        if (typeof ResizeObserver !== 'undefined') {
+            resizeObserver = new ResizeObserver(scheduleCompute)
+            resizeObserver.observe(document.documentElement)
+        }
+
+        // Fallback / additional safety net.
+        window.addEventListener('resize', scheduleCompute, { passive: true })
+        window.addEventListener('orientationchange', scheduleCompute, { passive: true })
+    })
+
+    // Recompute whenever the virtual dimensions or mode change.
+    watch(
+        () => [getWidth(), getHeight(), getMode()],
+        scheduleCompute
+    )
+
+    onBeforeUnmount(() => {
+        if (resizeObserver) {
+            resizeObserver.disconnect()
+            resizeObserver = null
+        }
+        window.removeEventListener('resize', scheduleCompute)
+        window.removeEventListener('orientationchange', scheduleCompute)
+        if (rafId != null) {
+            cancelAnimationFrame(rafId)
+            rafId = null
+        }
+    })
+
+    // CSS to apply to the virtual canvas element. It is sized exactly to the
+    // virtual dimensions and then transform-scaled from its top-left origin.
+    const style = computed(() => {
+        const width = getWidth()
+        const height = getHeight()
+        const transform =
+            scaleX.value === scaleY.value
+                ? `scale(${scaleX.value})`
+                : `scale(${scaleX.value}, ${scaleY.value})`
+        return {
+            width: `${width}px`,
+            height: `${height}px`,
+            transform,
+            transformOrigin: 'center center',
+        }
+    })
+
+    return { scale, scaleX, scaleY, style }
+}
+
+export default useScaleToFit

--- a/resources/js/Preview.vue
+++ b/resources/js/Preview.vue
@@ -1,0 +1,353 @@
+<script setup>
+import { computed, defineAsyncComponent, ref } from "vue";
+import NoneFallback from "@/Projects/System/Layouts/None.vue";
+import {
+    mockScreen,
+    mockRooms,
+    mockSchedule,
+    mockAnnouncements,
+    mockArtworks,
+} from "@/mock";
+
+/**
+ * Standalone design preview page.
+ *
+ * Renders ANY signage design Vue component with realistic mock data, with no
+ * database, no screens/playlists and no websocket (Reverb/Echo) server. It
+ * deliberately does NOT import Main.vue's logic (ping/Echo/etc).
+ *
+ * Props mirror what PreviewController passes.
+ */
+const props = defineProps({
+    project: { type: String, required: true },
+    pages: { type: Array, default: () => [] },
+    layouts: { type: Array, default: () => [] },
+    projects: { type: Array, default: () => [] },
+    selectedPage: { type: String, default: null },
+    selectedLayout: { type: String, default: "None" },
+});
+
+// ---- Mock data passed to the design (top-level props, exactly like prod) ----
+const appScreen = mockScreen();
+const rooms = mockRooms();
+const schedule = mockSchedule();
+const announcements = mockAnnouncements();
+const artworks = mockArtworks();
+
+const mockProps = {
+    connected: true,
+    appScreen,
+    rooms,
+    schedule,
+    artworks,
+    announcements,
+};
+
+// ---- Fake `page` object, identical in shape to production's ----
+const importError = ref(null);
+
+const resolvedComponent = defineAsyncComponent(() =>
+    import(`./Projects/${props.project}/Pages/${props.selectedPage}.vue`).catch(
+        (err) => {
+            importError.value = err;
+            return { template: "<div></div>" };
+        }
+    )
+);
+
+const page = computed(() => ({
+    resolvedComponent,
+    layout: { component: props.selectedLayout, path: props.project },
+    path: props.project,
+    component: props.selectedPage,
+    props: {},
+    duration: null,
+    title: null,
+    starts_at: null,
+    ends_at: null,
+    index: 0,
+}));
+
+// ---- Resolve the layout (fall back to System/None) ----
+const resolvedLayout = props.selectedLayout
+    ? defineAsyncComponent({
+          loader: () =>
+              import(
+                  `./Projects/${props.project}/Layouts/${props.selectedLayout}.vue`
+              ),
+          errorComponent: NoneFallback,
+      })
+    : NoneFallback;
+
+// ---- Dev toolbar state ----
+const params = new URLSearchParams(window.location.search);
+const bare = params.get("bare") === "1";
+const toolbarVisible = ref(!bare);
+
+const resolutions = [
+    { label: "1920 x 1080 (FHD)", w: 1920, h: 1080 },
+    { label: "3840 x 2160 (4K)", w: 3840, h: 2160 },
+    { label: "1080 x 1920 (Portrait)", w: 1080, h: 1920 },
+    { label: "1280 x 720 (HD)", w: 1280, h: 720 },
+    { label: "Fit window", w: 0, h: 0 },
+];
+const selectedResolution = ref(resolutions[0]);
+const showGrid = ref(false);
+
+// Scale the fixed-resolution canvas down to fit the viewport.
+const scale = ref(1);
+const stageStyle = computed(() => {
+    const r = selectedResolution.value;
+    if (!r.w || !r.h) {
+        return { width: "100vw", height: "100vh" };
+    }
+    return {
+        width: r.w + "px",
+        height: r.h + "px",
+        transform: `scale(${scale.value})`,
+        transformOrigin: "top left",
+    };
+});
+
+function recomputeScale() {
+    const r = selectedResolution.value;
+    if (!r.w || !r.h) {
+        scale.value = 1;
+        return;
+    }
+    const sw = window.innerWidth / r.w;
+    const sh = window.innerHeight / r.h;
+    scale.value = Math.min(sw, sh, 1);
+}
+
+if (typeof window !== "undefined") {
+    window.addEventListener("resize", recomputeScale);
+    recomputeScale();
+}
+
+function onResolutionChange() {
+    recomputeScale();
+}
+
+// ---- Navigation (plain URLs to avoid Ziggy timing issues) ----
+const pageChoice = ref(props.selectedPage);
+const layoutChoice = ref(props.selectedLayout);
+
+function navigate() {
+    const p = encodeURIComponent(pageChoice.value);
+    const l = encodeURIComponent(layoutChoice.value);
+    window.location.href = `/preview/${p}?layout=${l}`;
+}
+</script>
+
+<template>
+    <div class="preview-root">
+        <!-- DEV TOOLBAR -->
+        <div
+            v-if="toolbarVisible"
+            class="preview-toolbar"
+        >
+            <strong class="preview-title">Design Preview</strong>
+
+            <label class="preview-field">
+                <span>Page</span>
+                <select v-model="pageChoice" @change="navigate">
+                    <option v-for="p in pages" :key="p" :value="p">{{ p }}</option>
+                </select>
+            </label>
+
+            <label class="preview-field">
+                <span>Layout</span>
+                <select v-model="layoutChoice" @change="navigate">
+                    <option v-for="l in layouts" :key="l" :value="l">{{ l }}</option>
+                </select>
+            </label>
+
+            <label class="preview-field">
+                <span>Resolution</span>
+                <select v-model="selectedResolution" @change="onResolutionChange">
+                    <option
+                        v-for="r in resolutions"
+                        :key="r.label"
+                        :value="r"
+                    >
+                        {{ r.label }}
+                    </option>
+                </select>
+            </label>
+
+            <label
+                class="preview-field"
+                :title="'Project switching requires changing VITE_PROJECT_PATH in .env and rebuilding. This is informational only.'"
+            >
+                <span>Project</span>
+                <select :value="project" disabled>
+                    <option v-for="pr in projects" :key="pr" :value="pr">
+                        {{ pr }}
+                    </option>
+                </select>
+            </label>
+
+            <label class="preview-check">
+                <input type="checkbox" v-model="showGrid" />
+                <span>Grid</span>
+            </label>
+
+            <span class="preview-meta">
+                scale {{ Math.round(scale * 100) }}%
+            </span>
+
+            <button class="preview-hide" @click="toolbarVisible = false" title="Hide toolbar (add ?bare=1 to start hidden)">
+                Hide ✕
+            </button>
+        </div>
+
+        <!-- STAGE -->
+        <div class="preview-stage-wrap">
+            <div class="preview-stage" :style="stageStyle">
+                <div v-if="importError" class="preview-error">
+                    <h2>Failed to load design</h2>
+                    <p>
+                        Could not import
+                        <code>Projects/{{ project }}/Pages/{{ selectedPage }}.vue</code>.
+                    </p>
+                    <pre>{{ String(importError) }}</pre>
+                </div>
+                <Suspense v-else>
+                    <component
+                        :is="resolvedLayout"
+                        :page="page"
+                        v-bind="mockProps"
+                    />
+                    <template #fallback>
+                        <div class="preview-loading">Loading design…</div>
+                    </template>
+                </Suspense>
+
+                <!-- Grid overlay -->
+                <div v-if="showGrid" class="preview-grid"></div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.preview-root {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    background: #111;
+}
+
+.preview-toolbar {
+    position: fixed;
+    top: 8px;
+    left: 8px;
+    z-index: 99999;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 10px;
+    background: rgba(20, 20, 20, 0.82);
+    color: #fff;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 12px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(4px);
+    max-width: calc(100vw - 16px);
+}
+
+.preview-title {
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+
+.preview-field {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.preview-field > span {
+    opacity: 0.7;
+}
+
+.preview-toolbar select,
+.preview-toolbar button {
+    background: #2a2a2a;
+    color: #fff;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 12px;
+}
+
+.preview-toolbar select:disabled {
+    opacity: 0.5;
+}
+
+.preview-check {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+}
+
+.preview-meta {
+    opacity: 0.6;
+}
+
+.preview-hide {
+    cursor: pointer;
+}
+
+.preview-stage-wrap {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.preview-stage {
+    position: relative;
+    overflow: hidden;
+    background: #000;
+}
+
+.preview-grid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9999;
+    background-image: linear-gradient(
+            to right,
+            rgba(255, 255, 255, 0.15) 1px,
+            transparent 1px
+        ),
+        linear-gradient(
+            to bottom,
+            rgba(255, 255, 255, 0.15) 1px,
+            transparent 1px
+        );
+    background-size: 96px 96px;
+}
+
+.preview-error {
+    color: #fff;
+    padding: 40px;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+.preview-error pre {
+    white-space: pre-wrap;
+    color: #f87171;
+    font-size: 12px;
+}
+
+.preview-loading {
+    color: #fff;
+    padding: 40px;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+}
+</style>

--- a/resources/js/Projects/Starter/Components/Clock.vue
+++ b/resources/js/Projects/Starter/Components/Clock.vue
@@ -1,0 +1,21 @@
+<script setup>
+// Live clock used across Starter designs.
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import { DateTime } from "luxon";
+
+const props = defineProps({
+    format: { type: String, default: "HH:mm" },
+});
+
+const now = ref(DateTime.now());
+let timer = null;
+
+onMounted(() => {
+    timer = setInterval(() => (now.value = DateTime.now()), 1000);
+});
+onBeforeUnmount(() => clearInterval(timer));
+</script>
+
+<template>
+    <span class="tabular-nums">{{ now.toFormat(format) }}</span>
+</template>

--- a/resources/js/Projects/Starter/Layouts/Grid.vue
+++ b/resources/js/Projects/Starter/Layouts/Grid.vue
@@ -1,0 +1,83 @@
+<script setup>
+// Starter "Grid" layout.
+//
+// Establishes the resolution-independent virtual canvas (1920x1080) via
+// AutoScale and paints a themed background. Any page rendered through this
+// layout is authored against a fixed 1920x1080 box and uniformly scaled to fit
+// the real screen — never larger than the screen. Pages then compose their
+// content with the <Grid>/<Block> primitives.
+import { computed, reactive, useAttrs } from "vue";
+import { AutoScale } from "@/Components/Grid";
+
+const props = defineProps(["page"]);
+
+defineOptions({ inheritAttrs: false });
+
+const attrs = reactive(useAttrs());
+
+// Mirror the shared layout contract: forward all screen data + the page's own
+// configured props down into the design component.
+const usableAttributes = computed(() => ({
+    ...attrs,
+    page: props.page,
+    ...props.page.props,
+}));
+</script>
+
+<template>
+    <AutoScale :width="1920" :height="1080" mode="contain" background="#0f172a">
+        <!-- Themed canvas backdrop -->
+        <div class="canvas">
+            <div class="canvas-bg"></div>
+            <Transition mode="out-in">
+                <component
+                    :is="page.resolvedComponent"
+                    v-bind="usableAttributes"
+                />
+            </Transition>
+        </div>
+    </AutoScale>
+</template>
+
+<style scoped>
+.canvas {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    color: #fff;
+}
+
+.canvas-bg {
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(
+            1200px 800px at 15% -10%,
+            rgba(99, 102, 241, 0.35),
+            transparent 60%
+        ),
+        radial-gradient(
+            1000px 700px at 110% 120%,
+            rgba(34, 211, 238, 0.22),
+            transparent 55%
+        ),
+        #0f172a;
+    z-index: 0;
+}
+
+.canvas > :not(.canvas-bg) {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+}
+
+.v-enter-active,
+.v-leave-active {
+    transition: opacity 0.6s ease;
+}
+.v-enter-from,
+.v-leave-to {
+    opacity: 0;
+}
+</style>

--- a/resources/js/Projects/Starter/Layouts/None.vue
+++ b/resources/js/Projects/Starter/Layouts/None.vue
@@ -1,0 +1,52 @@
+<script setup>
+// Starter "None" layout.
+//
+// Like the Grid layout it provides the 1920x1080 AutoScale virtual canvas (so
+// designs stay resolution-independent) but with no themed background chrome —
+// the design owns the whole frame.
+import { computed, reactive, useAttrs } from "vue";
+import { AutoScale } from "@/Components/Grid";
+
+const props = defineProps(["page"]);
+
+defineOptions({ inheritAttrs: false });
+
+const attrs = reactive(useAttrs());
+
+const usableAttributes = computed(() => ({
+    ...attrs,
+    page: props.page,
+    ...props.page.props,
+}));
+</script>
+
+<template>
+    <AutoScale :width="1920" :height="1080" mode="contain" background="#0f172a">
+        <div class="canvas">
+            <Transition mode="out-in">
+                <component
+                    :is="page.resolvedComponent"
+                    v-bind="usableAttributes"
+                />
+            </Transition>
+        </div>
+    </AutoScale>
+</template>
+
+<style scoped>
+.canvas {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    color: #fff;
+}
+
+.v-enter-active,
+.v-leave-active {
+    transition: opacity 0.6s ease;
+}
+.v-enter-from,
+.v-leave-to {
+    opacity: 0;
+}
+</style>

--- a/resources/js/Projects/Starter/Pages/Announcements.vue
+++ b/resources/js/Projects/Starter/Pages/Announcements.vue
@@ -1,0 +1,59 @@
+<script setup>
+// Announcements — renders via the "None" layout (no themed chrome), so it owns
+// its own background. Tiles every active announcement into an `auto-fit` grid
+// and uses <FitText> so longer announcements scale down to fit their tile.
+import { computed } from "vue";
+import { DateTime } from "luxon";
+import { Grid, Block } from "@/Components/Grid";
+
+const props = defineProps({
+    title: { type: String, default: "Announcements" },
+    announcements: { type: Array, default: () => [] },
+});
+
+const items = computed(() => {
+    const now = DateTime.now();
+    return (props.announcements ?? []).filter((a) => {
+        if (!a) return false;
+        const startOk = !a.starts_at || DateTime.fromISO(a.starts_at) <= now;
+        const endOk = !a.ends_at || DateTime.fromISO(a.ends_at) >= now;
+        return startOk && endOk;
+    });
+});
+</script>
+
+<template>
+    <div class="flex h-full w-full flex-col bg-primary-900 p-14">
+        <h1 class="mb-8 shrink-0 text-7xl font-black tracking-tight text-white">
+            {{ title }}
+        </h1>
+
+        <div class="min-h-0 flex-1">
+            <Grid auto-fit gap="1.5rem">
+                <Block
+                    v-for="(item, i) in items"
+                    :key="item.id ?? i"
+                    class="surface"
+                    title=""
+                    fit
+                    align="start"
+                    padding="2.5rem"
+                >
+                    <template #header>
+                        <div class="text-5xl font-bold text-accent-400">
+                            {{ item.title }}
+                        </div>
+                    </template>
+                    <div
+                        class="prose-invert text-4xl font-light leading-snug text-white/80"
+                        v-html="item.content"
+                    ></div>
+                </Block>
+
+                <Block v-if="items.length === 0" align="center" fit>
+                    <span class="text-5xl text-white/50">No announcements</span>
+                </Block>
+            </Grid>
+        </div>
+    </div>
+</template>

--- a/resources/js/Projects/Starter/Pages/RoomGrid.vue
+++ b/resources/js/Projects/Starter/Pages/RoomGrid.vue
@@ -1,0 +1,58 @@
+<script setup>
+// RoomGrid — the auto-fit + scale-to-fit showcase (Alamos-style).
+//
+// Drops every room into an `auto-fit` <Grid>: the grid automatically arranges
+// the N tiles into a near-square layout and sizes them equally. Add a room and
+// every tile shrinks to keep the whole grid inside the screen — it never grows
+// past the canvas. <FitText> keeps each room name inside its tile.
+import { computed } from "vue";
+import { Grid, Block, FitText } from "@/Components/Grid";
+
+const props = defineProps({
+    title: { type: String, default: "Rooms" },
+    // Forwarded by the layout (mock data in preview, live data on a screen).
+    rooms: { type: Array, default: () => [] },
+});
+
+const roomList = computed(() =>
+    (props.rooms ?? []).filter((r) => r && (r.name || r.venue_name)),
+);
+</script>
+
+<template>
+    <div class="flex h-full flex-col p-14">
+        <h1 class="mb-8 shrink-0 text-7xl font-black tracking-tight">
+            {{ title }}
+        </h1>
+
+        <!-- The grid fills the remaining space and auto-fits all rooms. -->
+        <div class="min-h-0 flex-1">
+            <Grid auto-fit gap="1.5rem">
+                <Block
+                    v-for="room in roomList"
+                    :key="room.id ?? room.name"
+                    class="surface !bg-white/[0.06]"
+                    align="center"
+                    fit
+                    padding="2rem"
+                >
+                    <div class="text-center">
+                        <div class="text-6xl font-bold leading-tight">
+                            {{ room.name }}
+                        </div>
+                        <div
+                            v-if="room.venue_name && room.venue_name !== room.name"
+                            class="mt-3 text-4xl font-light text-white/60"
+                        >
+                            {{ room.venue_name }}
+                        </div>
+                    </div>
+                </Block>
+
+                <Block v-if="roomList.length === 0" align="center" fit>
+                    <span class="text-5xl text-white/50">No rooms assigned</span>
+                </Block>
+            </Grid>
+        </div>
+    </div>
+</template>

--- a/resources/js/Projects/Starter/Pages/ScheduleBoard.vue
+++ b/resources/js/Projects/Starter/Pages/ScheduleBoard.vue
@@ -1,0 +1,83 @@
+<script setup>
+// ScheduleBoard — an upcoming-events board.
+//
+// Uses an explicit 1-column <Grid>: a header row plus one row per event. Because
+// every row is `minmax(0, 1fr)`, the rows always divide the canvas evenly and
+// the board never overflows — we just cap how many events are shown.
+import { computed } from "vue";
+import { DateTime } from "luxon";
+import { Grid, Block } from "@/Components/Grid";
+import Clock from "../Components/Clock.vue";
+
+const props = defineProps({
+    title: { type: String, default: "What's On" },
+    schedule: { type: Array, default: () => [] },
+});
+
+const MAX_ROWS = 6;
+
+const events = computed(() => {
+    const now = DateTime.now();
+    return (props.schedule ?? [])
+        .filter((e) => e && e.ends_at && DateTime.fromISO(e.ends_at) >= now)
+        .sort(
+            (a, b) =>
+                DateTime.fromISO(a.starts_at).toMillis() -
+                DateTime.fromISO(b.starts_at).toMillis(),
+        )
+        .slice(0, MAX_ROWS);
+});
+
+const fmt = (iso) => (iso ? DateTime.fromISO(iso).toFormat("HH:mm") : "--:--");
+</script>
+
+<template>
+    <Grid :columns="1" gap="1.25rem" padding="3rem">
+        <!-- Header -->
+        <Block padding="1.25rem 2.5rem" class="surface-accent !border-0">
+            <div class="flex h-full items-center justify-between">
+                <span class="text-7xl font-black tracking-tight">{{ title }}</span>
+                <span class="text-5xl font-light"><Clock format="HH:mm" /></span>
+            </div>
+        </Block>
+
+        <!-- One row per upcoming event -->
+        <Block
+            v-for="event in events"
+            :key="event.id ?? event.title"
+            padding="0 2.5rem"
+        >
+            <div class="flex h-full items-center gap-10">
+                <div
+                    class="w-64 shrink-0 text-6xl font-bold tabular-nums text-accent-400"
+                >
+                    {{ fmt(event.starts_at) }}
+                </div>
+                <div class="min-w-0 flex-1">
+                    <div class="truncate text-5xl font-semibold">
+                        {{ event.title }}
+                    </div>
+                    <div class="mt-1 text-3xl font-light text-white/60">
+                        {{ event.room?.name ?? "" }}
+                    </div>
+                </div>
+                <div
+                    v-if="event.delay"
+                    class="shrink-0 rounded-full bg-warning-500/20 px-6 py-2 text-3xl font-semibold text-warning-400"
+                >
+                    +{{ event.delay }} min
+                </div>
+                <div
+                    v-else
+                    class="shrink-0 text-3xl font-medium text-success-400"
+                >
+                    On time
+                </div>
+            </div>
+        </Block>
+
+        <Block v-if="events.length === 0" align="center">
+            <span class="text-5xl text-white/50">Nothing scheduled</span>
+        </Block>
+    </Grid>
+</template>

--- a/resources/js/Projects/Starter/Pages/Welcome.vue
+++ b/resources/js/Projects/Starter/Pages/Welcome.vue
@@ -1,0 +1,56 @@
+<script setup>
+// Welcome — a hero splash design.
+//
+// Demonstrates the layout backbone: a 12-column <Grid> with explicit row spans
+// that always fills the 1920x1080 canvas, plus <FitText> so a long title scales
+// down to fit its tile instead of overflowing.
+import { Grid, Block, FitText } from "@/Components/Grid";
+import Clock from "../Components/Clock.vue";
+
+defineProps({
+    // Page-configured props (from the playlist item content / page schema).
+    title: { type: String, default: "Welcome to Open Signage" },
+    subtitle: { type: String, default: "Build signage designs, fast." },
+    // Screen data forwarded by the layout.
+    appScreen: { type: Object, default: () => ({}) },
+});
+</script>
+
+<template>
+    <Grid :columns="12" gap="2rem" padding="3.5rem">
+        <!-- Top bar -->
+        <Block :col-span="12" :row-span="1" padding="1.5rem 2.5rem">
+            <div class="flex h-full items-center justify-between">
+                <div class="flex items-center gap-4">
+                    <div class="h-10 w-10 rounded-xl surface-accent"></div>
+                    <span class="text-4xl font-semibold tracking-tight"
+                        >Open Signage</span
+                    >
+                </div>
+                <span class="text-5xl font-light tabular-nums text-white/80">
+                    <Clock format="HH:mm" />
+                </span>
+            </div>
+        </Block>
+
+        <!-- Hero -->
+        <Block :col-span="12" :row-span="4" align="center" fit padding="4rem">
+            <div class="text-center">
+                <h1 class="text-9xl font-black leading-none tracking-tight">
+                    {{ title }}
+                </h1>
+                <p class="mt-8 text-6xl font-light text-white/70">
+                    {{ subtitle }}
+                </p>
+            </div>
+        </Block>
+
+        <!-- Footer -->
+        <Block :col-span="12" :row-span="1" padding="1.5rem 2.5rem">
+            <div class="flex h-full items-center justify-between text-3xl text-white/50">
+                <span>{{ appScreen?.name ?? "Preview" }}</span>
+                <span>Powered by Open Signage</span>
+            </div>
+        </Block>
+    </Grid>
+</template>

--- a/resources/js/Projects/Starter/app.css
+++ b/resources/js/Projects/Starter/app.css
@@ -1,0 +1,35 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+ * Starter project global styles.
+ *
+ * Designs are authored against a fixed 1920x1080 "virtual canvas" (see the
+ * AutoScale component in the layouts) and then uniformly scaled to fit any
+ * screen, so font sizes / paddings here are absolute and resolution-independent.
+ */
+
+:root {
+    --starter-font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+}
+
+body {
+    overflow: hidden;
+    font-family: var(--starter-font);
+    background: #0f172a;
+    color: #fff;
+}
+
+/* A soft, modern surface for grid tiles. Override per-block with classes. */
+.surface {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(2px);
+}
+
+.surface-accent {
+    background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}

--- a/resources/js/Projects/Starter/theme.js
+++ b/resources/js/Projects/Starter/theme.js
@@ -1,0 +1,36 @@
+const colors = require("tailwindcss/colors");
+
+// Tailwind theme for the Starter project. This object is merged into
+// `theme.extend` by tailwind.config.js (keyed off VITE_PROJECT_PATH), so the
+// classes below (e.g. `bg-primary`, `text-accent`, `bg-primary-700`) are
+// available throughout the Starter designs. Swap these values to re-skin the
+// whole project in one place.
+module.exports = {
+    colors: {
+        primary: {
+            DEFAULT: "#1e293b", // slate-800
+            50: "#f8fafc",
+            100: "#f1f5f9",
+            200: "#e2e8f0",
+            300: "#cbd5e1",
+            400: "#94a3b8",
+            500: "#64748b",
+            600: "#475569",
+            700: "#334155",
+            800: "#1e293b",
+            900: "#0f172a",
+            950: "#020617",
+        },
+        accent: {
+            DEFAULT: "#6366f1", // indigo-500
+            400: "#818cf8",
+            500: "#6366f1",
+            600: "#4f46e5",
+        },
+        main: "#6366f1",
+        secondary: "#22d3ee",
+        danger: colors.rose,
+        success: colors.emerald,
+        warning: colors.amber,
+    },
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,6 +5,7 @@ import { resolvePageComponent } from "laravel-vite-plugin/inertia-helpers";
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 import * as Sentry from "@sentry/vue";
 import Main from "./Main.vue";
+import Preview from "./Preview.vue";
 
 import.meta.glob(["./Projects/**/Assets/**"]);
 
@@ -14,9 +15,7 @@ import(`./Projects/${appPath}/app.css`);
 
 createInertiaApp({
     title: (title) => `${appName}`,
-    resolve: (name) => {
-        return Main;
-    },
+    resolve: (name) => ({ Main, Preview }[name] ?? Main),
     setup({ el, App, props, plugin }) {
         const app = createApp({ render: () => h(App, props) })
             .use(plugin)

--- a/resources/js/mock/index.js
+++ b/resources/js/mock/index.js
@@ -1,0 +1,197 @@
+/**
+ * Mock data for the design preview workflow (`/preview`).
+ *
+ * These functions mirror the shapes produced by
+ * `app/Services/ScreenDataGenerator.php` so that signage designs render with
+ * realistic data WITHOUT a database, screens, playlists or websocket server.
+ *
+ * Everything is plain JS and deterministic-ish (times are computed relative to
+ * `new Date()` so the schedule always looks "live"). Tweak freely while
+ * developing a design — nothing here touches the backend.
+ */
+
+// Anchor everything to "now" so previews always look current.
+const NOW = new Date();
+
+/** Build an ISO string offset from now by a number of minutes. */
+function iso(offsetMinutes = 0) {
+    return new Date(NOW.getTime() + offsetMinutes * 60_000).toISOString();
+}
+
+/** Build the `pivot` object every room carries (see Screen::rooms withPivot). */
+function pivot(overrides = {}) {
+    return {
+        sort: 0,
+        rotation: 0,
+        mirror: false,
+        icon: null,
+        flags: null,
+        starts_at: null,
+        ends_at: null,
+        ...overrides,
+    };
+}
+
+export function mockRooms() {
+    return [
+        {
+            id: 1,
+            name: "Main Stage",
+            venue_name: "Main Stage",
+            pivot: pivot({ sort: 1, icon: "arrow-up", flags: "wheelchair" }),
+        },
+        {
+            id: 2,
+            name: "Workshop Room A",
+            venue_name: "Workshop Room A",
+            pivot: pivot({ sort: 2, icon: "arrow-right", flags: "first_aid" }),
+        },
+        {
+            id: 3,
+            name: "Workshop Room B",
+            venue_name: "Workshop Room B",
+            pivot: pivot({ sort: 3, icon: "arrow-left" }),
+        },
+        {
+            id: 4,
+            name: "Art Gallery",
+            venue_name: "Art Gallery",
+            pivot: pivot({ sort: 4, icon: "arrow-up", rotation: 90 }),
+        },
+        {
+            id: 5,
+            name: "Dealers Den",
+            venue_name: "Dealers Den",
+            pivot: pivot({ sort: 5, icon: "arrow-down", flags: "wheelchair,first_aid" }),
+        },
+    ];
+}
+
+export function mockScreen() {
+    return {
+        id: 1,
+        name: "Preview Screen",
+        slug: "preview-screen",
+        hostname: "preview.local",
+        orientation: "landscape",
+        version: 1,
+        status: "online",
+        playlist_id: 1,
+        screen_group_id: null,
+        room_id: 1,
+        room: mockRooms()[0],
+        rooms: mockRooms(),
+    };
+}
+
+/**
+ * A schedule with 8-12 entries spread across "today", a couple of which are
+ * delayed. Each entry matches the ScheduleEntry shape consumed by designs:
+ * `room`, `scheduleType`, `scheduleOrganizer`, `starts_at`, `ends_at`,
+ * `title`, `delay`.
+ */
+export function mockSchedule() {
+    const rooms = mockRooms();
+
+    const types = [
+        { id: 1, name: "Panel", color: "#3b82f6" },
+        { id: 2, name: "Workshop", color: "#10b981" },
+        { id: 3, name: "Performance", color: "#f59e0b" },
+        { id: 4, name: "Social", color: "#ec4899" },
+    ];
+
+    const organizers = [
+        { id: 1, name: "Programming Team" },
+        { id: 2, name: "Guest Crew" },
+        { id: 3, name: "Volunteers" },
+    ];
+
+    const entries = [
+        { title: "Opening Ceremony", room: 0, type: 0, org: 0, start: -90, len: 60, delay: 0 },
+        { title: "Welcome to the Con", room: 1, type: 0, org: 0, start: -30, len: 45, delay: 0 },
+        { title: "Beginner Fursuit Making", room: 2, type: 1, org: 2, start: -15, len: 90, delay: 10 },
+        { title: "Live Music Showcase", room: 0, type: 2, org: 1, start: 30, len: 60, delay: 0 },
+        { title: "Art Critique Roundtable", room: 3, type: 0, org: 0, start: 45, len: 50, delay: 0 },
+        { title: "Dealers Den Meet & Greet", room: 4, type: 3, org: 2, start: 60, len: 120, delay: 25 },
+        { title: "Digital Painting 101", room: 1, type: 1, org: 2, start: 90, len: 75, delay: 0 },
+        { title: "Dance Competition", room: 0, type: 2, org: 1, start: 150, len: 90, delay: 0 },
+        { title: "Charity Auction", room: 0, type: 3, org: 0, start: 240, len: 60, delay: 0 },
+        { title: "Closing Ceremony", room: 0, type: 0, org: 0, start: 300, len: 60, delay: 0 },
+    ];
+
+    return entries.map((e, index) => ({
+        id: index + 1,
+        title: e.title,
+        starts_at: iso(e.start),
+        ends_at: iso(e.start + e.len),
+        delay: e.delay,
+        room: rooms[e.room],
+        scheduleType: types[e.type],
+        scheduleOrganizer: organizers[e.org],
+    }));
+}
+
+export function mockAnnouncements() {
+    return [
+        {
+            id: 1,
+            title: "Welcome!",
+            content: "Welcome to the convention. Check the schedule for today's events.",
+            created_at: iso(-120),
+            updated_at: iso(-120),
+        },
+        {
+            id: 2,
+            title: "Lost & Found",
+            content: "Lost something? Visit the info desk near the main entrance.",
+            created_at: iso(-60),
+            updated_at: iso(-60),
+        },
+        {
+            id: 3,
+            title: "Photo Policy",
+            content: "Please ask before taking photos of fursuiters. Be respectful.",
+            created_at: iso(-30),
+            updated_at: iso(-30),
+        },
+    ];
+}
+
+export function mockArtworks() {
+    return [
+        {
+            id: 1,
+            name: "Aurora Fields",
+            artist: "Jamie Rivers",
+            horizontal: "https://placehold.co/1920x1080/1e293b/ffffff?text=Aurora+Fields",
+            vertical: "https://placehold.co/1080x1920/1e293b/ffffff?text=Aurora+Fields",
+            banner: "https://placehold.co/1920x480/1e293b/ffffff?text=Aurora+Fields",
+        },
+        {
+            id: 2,
+            name: "Neon Den",
+            artist: "Sky Vasquez",
+            horizontal: "https://placehold.co/1920x1080/312e81/ffffff?text=Neon+Den",
+            vertical: "https://placehold.co/1080x1920/312e81/ffffff?text=Neon+Den",
+            banner: "https://placehold.co/1920x480/312e81/ffffff?text=Neon+Den",
+        },
+        {
+            id: 3,
+            name: "Quiet Forest",
+            artist: "Robin Ash",
+            horizontal: "https://placehold.co/1920x1080/064e3b/ffffff?text=Quiet+Forest",
+            vertical: "https://placehold.co/1080x1920/064e3b/ffffff?text=Quiet+Forest",
+            banner: "https://placehold.co/1920x480/064e3b/ffffff?text=Quiet+Forest",
+        },
+    ];
+}
+
+export const mockData = {
+    screen: mockScreen,
+    rooms: mockRooms,
+    schedule: mockSchedule,
+    announcements: mockAnnouncements,
+    artworks: mockArtworks,
+};
+
+export default mockData;

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,3 +31,8 @@ Route::get('/', function () {
 
 Route::get('timetable', \App\Http\Controllers\TimetableController::class)->name('timetable');
 Route::get('efsched', \App\Http\Controllers\EurofurenceScheduleController::class)->name('efsched');
+
+// Dev-only design preview. Outside the shared-secret group on purpose: previewing
+// a design must not require a shared secret. The controller itself gates access
+// to debug/local environments only.
+Route::get('preview/{component?}', \App\Http\Controllers\PreviewController::class)->name('preview');


### PR DESCRIPTION
## Why

This is the **breaking-changes "next" foundation** that repositions Open Signage from an event-specific deployment into a **framework for building signage designs**. It tackles the two asks: make design development dev-friendly, and add an Alamos-style grid system that auto-extends but never grows larger than the screen.

Designs were previously hardcoded to a single resolution and could only be seen by standing up the whole stack (DB + screens + playlists + Reverb). This PR removes that friction.

## What's in it

### 🧩 Auto-fit + scale-to-fit grid system — `resources/js/Components/Grid/`
- **`AutoScale`** — wraps a design in a fixed virtual canvas (default 1920×1080) and uniformly scales it to fit any viewport (`contain`). Resolution independence + the "never larger than the screen" guarantee.
- **`Grid`** — CSS-grid container with `minmax(0,1fr)` tracks: it auto-extends as you add blocks but never overflows. `auto-fit` mode arranges N blocks into a near-square layout automatically.
- **`Block` / `FitText`** — grid tiles with span control and content that shrinks to fit its tile.
- Full prop reference in `resources/js/Components/Grid/README.md`.

### 🔍 Standalone design preview — `/preview` (dev-only)
- `PreviewController` + `Route::get('preview/{component?}')` render **any** design component on its own with realistic **mock data** — **no database, playlist, screen or websocket server required**.
- `resources/js/Preview.vue` dev harness with a toolbar (switch page/layout, change canvas resolution, grid overlay; `?bare=1` to hide it). `resources/js/mock/` provides mock screen data mirroring `ScreenDataGenerator`.
- Gated behind `APP_DEBUG`/`local`.

### 🌱 Working demo on a fresh clone — seeders
- `StarterSeeder` seeds a `demo` screen, a `Starter Demo` playlist, 5 rooms, 10 schedule entries and 3 announcements, so `php artisan migrate --seed` → `/screens/demo` just works.
- `DatabaseSeeder` now runs `StarterSeeder` and **stops auto-running the event-specific seeders** (`WildTimes`/`Eurofurence`/`Furciety` — files kept, still runnable manually).

### ✨ Starter example project (new default `VITE_PROJECT_PATH`)
- `Grid`/`None` layouts and `Welcome`, `ScheduleBoard`, `RoomGrid`, `Announcements` pages built on the grid system — `RoomGrid` demonstrates auto-fit + scale-to-fit.

### 📖 Docs
- README rewritten around the framework workflow; new `docs/DEVELOPMENT.md` covering the grid system, preview workflow and how to create your own project.

## Verification
- ✅ `npm run build` compiles all new components.
- ✅ `php artisan serve` + `/preview` returns 200 and lists the Starter pages/layouts **without a database**.
- ✅ `php artisan migrate --seed` runs cleanly (SQLite smoke test); the seeded `demo` screen, playlist items, rooms, schedule and announcements are coherent and the playlist items map exactly to the authored Vue pages.

## Deliberately *not* in this PR
To avoid breaking the live Eurofurence signage in the same PR that introduces its replacement, the **EF29 / Emergency projects and event-specific controllers (CCH, Eurofurence schedule import) are left in place**. Now that the generic foundation exists, extracting those into their own repository is a clean, well-scoped follow-up — happy to do it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzjXpht5JUdzmvsshV5ae8)_