### PR TITLE
publish to ghcr

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,29 @@
+name: Docker Build and Publish
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-**'
+
   release:
     types:
-      - created
+      - published
+
 jobs:
-  build-docker:
-    uses: Thiritin/workflows/.github/workflows/docker-semver.yml@main
+  build-and-push-image:
+    uses: eurofurence/workflows/.github/workflows/docker-buildx-push.yml@main
+
+    permissions:
+      contents: read
+      packages: write
+
+    with:
+      image-name: ${{ github.repository }}
+      dockerfile: ./Dockerfile
+      # build-context: .
+      # build-args: '--build-arg FOO=bar'
+
     secrets:
-      DockerHubUser: ${{ secrets.DOCKERHUB_USERNAME }}
-      DockerHubPass: ${{ secrets.DOCKERHUB_PASSWORD }}
-      DockerHubPrefix: eurofurence
+      ghcr-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
wah

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container publishing workflow to use the shared build and publish process.
  * Container images are now published for main branch updates, semantic-version tags, and released versions.
  * Improved package publishing permissions and removed legacy Docker Hub credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->